### PR TITLE
Add seedSelectedVals prop, that will allow the multiple select list …

### DIFF
--- a/components/MultipleSelectList.tsx
+++ b/components/MultipleSelectList.tsx
@@ -42,13 +42,14 @@ const MultipleSelectList: React.FC<MultipleSelectListProps> = ({
         badgeTextStyles,
         checkBoxStyles,
         save = 'key',
-        dropdownShown = false
+        dropdownShown = false,
+        seedSelectedVals = []
     }) => {
 
     const oldOption = React.useRef(null)
     const [_firstRender,_setFirstRender] = React.useState<boolean>(true);
     const [dropdown, setDropdown] = React.useState<boolean>(dropdownShown);
-    const [selectedval, setSelectedVal] = React.useState<any>([]);
+    const [selectedval, setSelectedVal] = React.useState<any>(seedSelectedVals);
     const [height,setHeight] = React.useState<number>(350)
     const animatedvalue = React.useRef(new Animated.Value(0)).current;
     const [filtereddata,setFilteredData] = React.useState(data);

--- a/index.d.ts
+++ b/index.d.ts
@@ -117,6 +117,11 @@ export interface SelectListProps  {
 
 export interface MultipleSelectListProps  {
     /**
+     * the initial selected values of the multiple select list
+     */
+    seedSelectedVals?: Array<{}>,
+
+    /**
     * Fn to set Selected option value which will be stored in your local state
     */
     setSelected: Function,


### PR DESCRIPTION
Hey I'm raising a very simple MR to give the user the ability to "seed" initially selected values in the multiple select list.
I have introduced the optional prop seedSelectedVals, which the selectedval state in `.\components\MultipleSelectList.tsx` will draw from initially.