### PR TITLE
multi dropdown default option fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "editor.fontFamily": "'JetBrains Mono'",
-    "workbench.colorTheme": "GitHub Dark Default",
-    "workbench.preferredDarkColorTheme": "Default Dark+",
-    "workbench.preferredHighContrastColorTheme": "Default High Contrast"
-}

--- a/components/MultipleSelectList.tsx
+++ b/components/MultipleSelectList.tsx
@@ -42,13 +42,14 @@ const MultipleSelectList: React.FC<MultipleSelectListProps> = ({
         badgeTextStyles,
         checkBoxStyles,
         save = 'key',
-        dropdownShown = false
+        dropdownShown = false,
+        defaultOption
     }) => {
 
     const oldOption = React.useRef(null)
     const [_firstRender,_setFirstRender] = React.useState<boolean>(true);
     const [dropdown, setDropdown] = React.useState<boolean>(dropdownShown);
-    const [selectedval, setSelectedVal] = React.useState<any>([]);
+    const [selectedval, setSelectedVal] = React.useState<any>(defaultOption);
     const [height,setHeight] = React.useState<number>(350)
     const animatedvalue = React.useRef(new Animated.Value(0)).current;
     const [filtereddata,setFilteredData] = React.useState(data);


### PR DESCRIPTION
This package really is a life saver for us as it allows us to use a searchable dropdown inside a scrollview, other packages we could not use it and in our app we need drop downs everywhere. Though as this package uses scrollview instead of flatlist but even for 100-200 data in dropdowns it is performing quite well.

But the main problem right now with this package is we can't get default option working in MultiSelect Dropdown so if we want to pre-fill selected data then we were unable to do it.

So I have come up with a solution and fixed the multioption default option which was not working. Though I have tested But this feature is a much needed for me so I would request you to test and merge this fix.

In DefaultOption though instead of key value pair we have to give normal array of strings. 

` 
<MultipleSelectList 
        setSelected={(val) => setSelected(val)} 
        data={data} 
        save="value"
        onSelect={() => alert(selected)} 
        label="Categories"
        defaultOption={['Computers', 'Cameras']}
    />
`

So this is how we can use default option.