### PR TITLE
Adds `onOpen` / `onClose` callback props

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ For Live `Demo` [(Expo Snack)](https://snack.expo.dev/@danish1658/react-native-d
 | ---- | ---- | ----------- |
 | save| string | Pass ('key' or 'value') to save data of your choice in your local state variable
 | onSelect| Function | Pass any function that you want to trigger immediately after a value is selected
+| onOpen| Function | Pass any function that you want to trigger when the dropdown is opened
+| onClose| Function | Pass any function that you want to trigger when the dropdown is closed
 | placeholder | String | Placeholder text that will be displayed in the select box
 | search | boolean | set to false if you dont want to use search functionality
 | maxHeight| Number | Maximum height of the dropdown wrapper to occupy

--- a/components/MultipleSelectList.tsx
+++ b/components/MultipleSelectList.tsx
@@ -34,6 +34,8 @@ const MultipleSelectList: React.FC<MultipleSelectListProps> = ({
         search = true,
         searchPlaceholder = "search",
         onSelect = () => {},
+        onOpen = () => {},
+        onClose = () => {},
         label,
         notFoundText = "No data found",
         disabledItemStyles,
@@ -58,22 +60,22 @@ const MultipleSelectList: React.FC<MultipleSelectListProps> = ({
 
     const slidedown = () => {
         setDropdown(true)
-        
         Animated.timing(animatedvalue,{
             toValue:height,
             duration:500,
             useNativeDriver:false,
             
         }).start()
+        onOpen()
     }
     const slideup = () => {
-        
         Animated.timing(animatedvalue,{
             toValue:0,
             duration:500,
             useNativeDriver:false,
             
         }).start(() => setDropdown(false))
+        onClose()
     }
 
     React.useEffect( () => {

--- a/components/SelectList.tsx
+++ b/components/SelectList.tsx
@@ -35,6 +35,8 @@ const SelectList: React.FC<SelectListProps> =  ({
         disabledItemStyles,
         disabledTextStyles,
         onSelect = () => {},
+        onOpen = () => {},
+        onClose = () => {},
         save = 'key',
         dropdownShown = false,
         fontFamily
@@ -57,15 +59,16 @@ const SelectList: React.FC<SelectListProps> =  ({
             useNativeDriver:false,
             
         }).start()
+        onOpen()
     }
     const slideup = () => {
-        
         Animated.timing(animatedvalue,{
             toValue:0,
             duration:500,
             useNativeDriver:false,
             
         }).start(() => setDropdown(false))
+        onClose()
     }
 
     React.useEffect( () => {

--- a/index.d.ts
+++ b/index.d.ts
@@ -79,6 +79,16 @@ export interface SelectListProps  {
     onSelect?: () => void,
 
     /**
+     * Trigger an action when dropdown is opened
+     */
+    onOpen?: () => void,
+
+    /**
+     * Trigger an action when dropdown is closed
+     */
+    onClose?: () => void,
+
+    /**
     * set fontFamily of whole component Text 
     */
     fontFamily?: string,
@@ -190,6 +200,16 @@ export interface MultipleSelectListProps  {
     * Trigger an action when option is selected
     */
     onSelect?: () => void,
+
+    /**
+    * Trigger an action when dropdown is opened
+    */
+    onOpen?: () => void,
+
+    /**
+    * Trigger an action when dropdown is closed
+    */
+    onClose?: () => void,
 
     /**
     * set text of label which appears soon after multiple values are selected


### PR DESCRIPTION
This PR adds `onOpen` and `onClose` callbacks to both dropdowns, so that we can do things like scroll the dropdown into view after it have been opened.