### PR TITLE
fix: change badgeTextStyles type from ViewStyle to TextStyle

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -251,7 +251,7 @@ export interface MultipleSelectListProps  {
     /**
     * Additional styles for multiselect badge text
     */
-    badgeTextStyles?: ViewStyle,
+    badgeTextStyles?: TextStyle,
 
     /**
     * Additional styles for label


### PR DESCRIPTION
fix(index.d.ts): change badgeTextStyles type from ViewStyle to TextStyle

Modified the type of `badgeTextStyles?` in `index.d.ts` from `ViewStyle` to `TextStyle` 
to ensure correct typing for text styling. This prevents TypeScript errors and ensures 
proper compatibility with text components in React Native.